### PR TITLE
FIX: e-mail non sauvegardé sur le tiers créé (DA020299) - 4.3.2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,5 @@
+# ChangeLog du module Wordpress Contact Form
+
+## 4.3
+- FIX: e-mail non sauvegardé sur le tiers créé (DA020299) - 4.3.2 - *17/05/2021*
+- No changelog up to this point

--- a/contact-form-7-to-dolibarr.php
+++ b/contact-form-7-to-dolibarr.php
@@ -22,7 +22,7 @@
   Version: 1.0
  */
 
-define('WPCF7_DOLIBARR_VERSION', '4.3.1');
+define('WPCF7_DOLIBARR_VERSION', '4.3.2');
 
 
 define('WPCF7_DOLIBARR_PLUGIN', __FILE__);

--- a/lib/dolibarr_sync.php
+++ b/lib/dolibarr_sync.php
@@ -42,7 +42,7 @@ class Wpcf7_dolibarr_sync
 			'headers' => ['DOLAPIKEY' => $datas['api_key']]
 		));
 
-		$this->setCompany($datas['field_company']);
+		$this->setCompany($datas['field_company'], $datas['field_email']);
 		$this->setContact($datas['field_lastname'], $datas['field_firstname'], $datas['field_email'], $datas['field_phone']);
 		$this->setMessage($datas['message']);
 		$this->setMessageSubject($datas['subject']);
@@ -51,8 +51,14 @@ class Wpcf7_dolibarr_sync
 		$this->ownerId = $datas['userownerid'];
 	}
 
-	private function setCompany($name) {
+	/**
+	 * @param string $name
+	 * @param string $email
+	 * @throws RestClientException
+	 */
+	private function setCompany($name, $email) {
 		$this->company['name'] = $name;
+		$this->company['email'] = $email;
 		$this->company['provenance'] = 'INT';
 
 		// Retreive FR country : Only work with DOL_VERSION >= 7.0
@@ -82,6 +88,12 @@ class Wpcf7_dolibarr_sync
 		$this->contact['id'] = $id;
 	}
 
+	/**
+	 * @param string $lastname
+	 * @param string $firstname
+	 * @param string $email
+	 * @param string $phone
+	 */
 	private function setContact($lastname, $firstname, $email, $phone) {
 		$this->contact['lastname'] = $lastname;
 		$this->contact['firstname'] = $firstname;


### PR DESCRIPTION
# FIX
- FIX: e-mail non sauvegardé sur le tiers créé (DA020299) - 4.3.2 - *17/05/2021*

Le contact est sauvegardé avec l’e-mail fourni, mais l’e-mail devrait aussi être sauvegardé sur le tiers car c’est l’e-mail qui est utilisé pour savoir si le tiers existe déjà.


**NOTE** : je n’ai pas pu tester le dev (environnement non Dolibarr) ;